### PR TITLE
Do not abstract StorageSwitch over content

### DIFF
--- a/crates/bevy_ecs/src/storage/blob_vec.rs
+++ b/crates/bevy_ecs/src/storage/blob_vec.rs
@@ -229,6 +229,22 @@ impl BlobVec {
         self.get_ptr().byte_add(index * self.item_layout.size())
     }
 
+    /// Get `T` at `index`. This is slightly faster than `get_unchecked` since
+    /// the stride is evaluated at compile time from `T` rather than dynamically
+    /// based on `self.item_layout`.
+    ///
+    /// # Safety
+    /// It is the caller's responsibility to ensure that `index` is < self.len(),
+    /// and that `T` is stored in the BlobVec.
+    #[inline]
+    pub unsafe fn get_unchecked_assuming<T>(&self, index: usize) -> &T {
+        debug_assert!(index < self.len());
+        debug_assert!(std::mem::size_of::<T>() == self.item_layout.size());
+        let ptr = (self.data.as_ptr() as *mut T).add(index);
+        // SAFE: ptr was taken from a NonNull
+        NonNull::new_unchecked(ptr).as_ref()
+    }
+
     /// # Safety
     /// It is the caller's responsibility to ensure that `index` is < self.len()
     #[inline]

--- a/crates/bevy_ecs/src/storage/table.rs
+++ b/crates/bevy_ecs/src/storage/table.rs
@@ -146,6 +146,13 @@ impl Column {
         self.data.get_slice()
     }
 
+    /// # Safety
+    /// The type `T` must be the type of the items in this column, `i` and must be within
+    /// bounds of the underlying table.
+    pub unsafe fn get_unchecked<T>(&self, row: usize) -> &UnsafeCell<T> {
+        self.data.get_unchecked_assuming(row)
+    }
+
     #[inline]
     pub fn get_ticks_slice(&self) -> &[UnsafeCell<ComponentTicks>] {
         &self.ticks
@@ -187,6 +194,16 @@ impl Column {
         for component_ticks in &mut self.ticks {
             component_ticks.get_mut().check_ticks(change_tick);
         }
+    }
+
+    /// # Safety
+    /// The type `T` must be the type of the items in this column, `i` and must be within
+    /// bounds of the underlying table.
+    pub(crate) unsafe fn get_with_ticks_unchecked<T>(
+        &self,
+        row: usize,
+    ) -> (&UnsafeCell<T>, &UnsafeCell<ComponentTicks>) {
+        (self.get_unchecked(row), self.get_ticks_unchecked(row))
     }
 }
 


### PR DESCRIPTION
~~I'm going to try to convert `StorageSwitch` to an associated type on `StorageType`, seems relatively straightforward.~~

We store &Column and &ComponentSparseSet in `StorageSwitch` rather than
abstract it over content, so that usages are clearer. This also
guarantees our union size is exactly the size of a pointer. Instead of
transforming the &Column into various references to columns when
constructing `StorageSwitch`, we just store the &Column. This required
updating access to account for this change.

Seemingly, this should not be a performance drop, since the level of
indirection is the same, and we unsafe_unwrap the same way as before.
