### PR TITLE
remove DetectChanges for &mut T

### DIFF
--- a/crates/bevy_ecs/src/change_detection.rs
+++ b/crates/bevy_ecs/src/change_detection.rs
@@ -23,7 +23,8 @@ pub const CHECK_TICK_THRESHOLD: u32 = 518_400_000;
 /// Changes stop being detected once they become this old.
 pub const MAX_CHANGE_AGE: u32 = u32::MAX - (2 * CHECK_TICK_THRESHOLD - 1);
 
-pub trait ComponentMut<'a>: DetectChanges {
+pub trait ComponentMut<'a> {
+    type Inner: ?Sized;
     const ENABLED: bool;
     fn build(
         inner: &'a mut Self::Inner,
@@ -400,6 +401,7 @@ where
 }
 
 impl<'a, T> ComponentMut<'a> for Mut<'a, T> {
+    type Inner = T;
     const ENABLED: bool = true;
     fn build(
         value: &'a mut Self::Inner,
@@ -424,37 +426,9 @@ change_detection_impl!(Mut<'a, T>, T, true,);
 impl_methods!(Mut<'a, T>, T,);
 impl_debug!(Mut<'a, T>,);
 
-impl<'a, T: ?Sized> DetectChanges for &'a mut T {
-    type Inner = T;
-
-    #[inline]
-    fn is_added(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    fn is_changed(&self) -> bool {
-        true
-    }
-
-    #[inline]
-    fn set_changed(&mut self) {}
-
-    #[inline]
-    fn last_changed(&self) -> u32 {
-        0
-    }
-
-    #[inline]
-    fn set_last_changed(&mut self, _last_change_tick: u32) {}
-
-    #[inline]
-    fn bypass_change_detection(&mut self) -> &mut Self::Inner {
-        self
-    }
-}
 
 impl<'a, T> ComponentMut<'a> for &'a mut T {
+    type Inner = T;
     const ENABLED: bool = false;
     fn build(
         value: &'a mut Self::Inner,

--- a/crates/bevy_ecs/src/component.rs
+++ b/crates/bevy_ecs/src/component.rs
@@ -127,7 +127,7 @@ use std::{
 /// [orphan rule]: https://doc.rust-lang.org/book/ch10-02-traits.html#implementing-a-trait-on-a-type
 /// [newtype pattern]: https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#using-the-newtype-pattern-to-implement-external-traits-on-external-types
 pub trait Component: Send + Sync + 'static {
-    type WriteFetch<'a>: ComponentMut<'a> + DetectChanges<Inner = Self> + DerefMut<Target = Self>;
+    type WriteFetch<'a>: ComponentMut<'a, Inner = Self> + DerefMut<Target = Self>;
     type Storage: ComponentStorage;
 
     fn shrink<'wlong: 'wshort, 'wshort>(


### PR DESCRIPTION
# Objective

- Avoid implementing `DetectChanges` for `&mut T` with a fake implementation
- the `DetectChanges` bound on `WriteFetch` in `Component` seemed unneeded?

