### PR TITLE
Ensure that `animatable` branch compiles

### DIFF
--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -1,5 +1,4 @@
 use crate::util;
-use bevy_asset::{Asset, Assets, Handle};
 use bevy_ecs::world::World;
 use bevy_math::*;
 use bevy_reflect::Reflect;
@@ -101,34 +100,6 @@ impl Animatable for bool {
             .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
             .map(|input| input.value)
             .unwrap_or(false)
-    }
-}
-
-impl<T: Asset> Animatable for Handle<T> {
-    #[inline]
-    fn interpolate(a: &Self, b: &Self, t: f32) -> Self {
-        util::step_unclamped(a.clone_weak(), b.clone_weak(), t)
-    }
-
-    #[inline]
-    fn blend(inputs: impl Iterator<Item = BlendInput<Self>>) -> Self {
-        inputs
-            .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
-            .map(|input| input.value)
-            .expect("Attempted to blend Handle with zero inputs.")
-    }
-
-    fn post_process(&mut self, world: &World) {
-        // Upgrade weak handles into strong ones.
-        if self.is_strong() {
-            return;
-        }
-        *self = world
-            .get_resource::<Assets<T>>()
-            .expect(
-                "Attempted to animate a Handle<T> without the corresponding Assets<T> resource.",
-            )
-            .get_handle(self.id());
     }
 }
 

--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -1,5 +1,5 @@
 use crate::util;
-use bevy_asset::{Asset, Assets, Handle, HandleId};
+use bevy_asset::{Asset, Assets, Handle};
 use bevy_ecs::world::World;
 use bevy_math::*;
 use bevy_reflect::Reflect;
@@ -101,21 +101,6 @@ impl Animatable for bool {
             .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
             .map(|input| input.value)
             .unwrap_or(false)
-    }
-}
-
-impl Animatable for HandleId {
-    #[inline]
-    fn interpolate(a: &Self, b: &Self, t: f32) -> Self {
-        util::step_unclamped(*a, *b, t)
-    }
-
-    #[inline]
-    fn blend(inputs: impl Iterator<Item = BlendInput<Self>>) -> Self {
-        inputs
-            .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
-            .map(|input| input.value)
-            .expect("Attempted to blend HandleId with zero inputs.")
     }
 }
 


### PR DESCRIPTION
This PR removes animatable trait impls for both `HandleId` and `Handle`.

In the case of `HandleId`, the type was removed completely.

In the case of `Handle`, I could not find a way to upgrade weak to strong handles in the current API. This was done previously.

Dealing with handles was also one of the more complex and controversial parts of the PR: severing it to ensure that the PR ships feels like the right choice regardless.

