### PR TITLE
Rename animatable::interpolate to linearly_interpolate

### DIFF
--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -1,5 +1,4 @@
 use crate::util;
-use bevy_asset::{Asset, Assets, Handle};
 use bevy_ecs::world::World;
 use bevy_math::*;
 use bevy_reflect::Reflect;
@@ -101,34 +100,6 @@ impl Animatable for bool {
             .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
             .map(|input| input.value)
             .unwrap_or(false)
-    }
-}
-
-impl<T: Asset> Animatable for Handle<T> {
-    #[inline]
-    fn interpolate(a: &Self, b: &Self, t: f32) -> Self {
-        util::step_unclamped(a.clone_weak(), b.clone_weak(), t)
-    }
-
-    #[inline]
-    fn blend(inputs: impl Iterator<Item = BlendInput<Self>>) -> Self {
-        inputs
-            .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
-            .map(|input| input.value)
-            .expect("Attempted to blend Handle with zero inputs.")
-    }
-
-    fn post_process(&mut self, world: &World) {
-        // Upgrade weak handles into strong ones.
-        if self.is_strong() {
-            return;
-        }
-        *self = world
-            .get_resource::<Assets<T>>()
-            .expect(
-                "Attempted to animate a Handle<T> without the corresponding Assets<T> resource.",
-            )
-            .get_handle(self.id());
     }
 }
 

--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -1,5 +1,5 @@
 use crate::util;
-use bevy_asset::{Asset, Assets, Handle, HandleId};
+use bevy_asset::{Asset, Assets, Handle};
 use bevy_ecs::world::World;
 use bevy_math::*;
 use bevy_reflect::Reflect;
@@ -101,21 +101,6 @@ impl Animatable for bool {
             .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
             .map(|input| input.value)
             .unwrap_or(false)
-    }
-}
-
-impl Animatable for HandleId {
-    #[inline]
-    fn interpolate(a: &Self, b: &Self, t: f32) -> Self {
-        util::step_unclamped(*a, *b, t)
-    }
-
-    #[inline]
-    fn blend(inputs: impl Iterator<Item = BlendInput<Self>>) -> Self {
-        inputs
-            .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
-            .map(|input| input.value)
-            .expect("Attempted to blend HandleId with zero inputs.")
     }
 }
 


### PR DESCRIPTION
Based on #6 so then things compile.

This PR renames the `interpolate` method following https://github.com/bevyengine/bevy/pull/4482/files#r1341926534 (which I agree) with.

I initially tried using `lerp`, but this ran into frustrations with the namespace collision between this trait method and existing `lerp` methods on many of the objects this trait is implemented for.