### PR TITLE
Use slerp for Quat interpolation

### DIFF
--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -121,7 +121,7 @@ impl Animatable for Transform {
             if input.additive {
                 translation += input.weight * Vec3A::from(input.value.translation);
                 scale += input.weight * Vec3A::from(input.value.scale);
-                rotation = (input.value.rotation * input.weight) * rotation;
+                rotation = rotation.slerp(input.value.rotation, input.weight);
             } else {
                 translation = Vec3A::interpolate(
                     &translation,

--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -146,14 +146,9 @@ impl Animatable for Quat {
     /// reference: <http://number-none.com/product/Understanding%20Slerp,%20Then%20Not%20Using%20It/>
     #[inline]
     fn interpolate(a: &Self, b: &Self, t: f32) -> Self {
-        // Make sure is always the short path, look at this: https://github.com/mgeier/quaternion-nursery
-        let b = if a.dot(*b) < 0.0 { -*b } else { *b };
-
-        let a: Vec4 = (*a).into();
-        let b: Vec4 = b.into();
-        let rot = Vec4::interpolate(&a, &b, t);
-        let inv_mag = bevy_math::approx_rsqrt(rot.dot(rot));
-        Quat::from_vec4(rot * inv_mag)
+        // We want to smoothly interpolate between the two quaternions by default,
+        // rather than using a quicker but less correct linear interpolation.
+        a.slerp(*b, t)
     }
 
     #[inline]

--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -1,5 +1,4 @@
 use crate::util;
-use bevy_asset::{Asset, Assets, Handle};
 use bevy_ecs::world::World;
 use bevy_math::*;
 use bevy_reflect::Reflect;
@@ -101,34 +100,6 @@ impl Animatable for bool {
             .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
             .map(|input| input.value)
             .unwrap_or(false)
-    }
-}
-
-impl<T: Asset> Animatable for Handle<T> {
-    #[inline]
-    fn interpolate(a: &Self, b: &Self, t: f32) -> Self {
-        util::step_unclamped(a.clone_weak(), b.clone_weak(), t)
-    }
-
-    #[inline]
-    fn blend(inputs: impl Iterator<Item = BlendInput<Self>>) -> Self {
-        inputs
-            .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
-            .map(|input| input.value)
-            .expect("Attempted to blend Handle with zero inputs.")
-    }
-
-    fn post_process(&mut self, world: &World) {
-        // Upgrade weak handles into strong ones.
-        if self.is_strong() {
-            return;
-        }
-        *self = world
-            .get_resource::<Assets<T>>()
-            .expect(
-                "Attempted to animate a Handle<T> without the corresponding Assets<T> resource.",
-            )
-            .get_handle(self.id());
     }
 }
 

--- a/crates/bevy_animation/src/animatable.rs
+++ b/crates/bevy_animation/src/animatable.rs
@@ -1,5 +1,5 @@
 use crate::util;
-use bevy_asset::{Asset, Assets, Handle, HandleId};
+use bevy_asset::{Asset, Assets, Handle};
 use bevy_ecs::world::World;
 use bevy_math::*;
 use bevy_reflect::Reflect;
@@ -101,21 +101,6 @@ impl Animatable for bool {
             .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
             .map(|input| input.value)
             .unwrap_or(false)
-    }
-}
-
-impl Animatable for HandleId {
-    #[inline]
-    fn interpolate(a: &Self, b: &Self, t: f32) -> Self {
-        util::step_unclamped(*a, *b, t)
-    }
-
-    #[inline]
-    fn blend(inputs: impl Iterator<Item = BlendInput<Self>>) -> Self {
-        inputs
-            .max_by(|a, b| FloatOrd(a.weight).cmp(&FloatOrd(b.weight)))
-            .map(|input| input.value)
-            .expect("Attempted to blend HandleId with zero inputs.")
     }
 }
 

--- a/crates/bevy_math/src/lib.rs
+++ b/crates/bevy_math/src/lib.rs
@@ -34,25 +34,3 @@ pub mod prelude {
 }
 
 pub use glam::*;
-
-/// Fast approximated reciprocal square root.
-#[inline]
-pub fn approx_rsqrt(x: f32) -> f32 {
-    // Quake 3 fast inverse sqrt, has a higher error but still good
-    // enough and faster than `.sqrt().recip()`, implementation
-    // borrowed from Piston under the MIT License:
-    // [https://github.com/PistonDevelopers/skeletal_animation]
-    //
-    // Includes a refinement seen in [http://rrrola.wz.cz/inv_sqrt.html]
-    // that improves overall accuracy by 2.7x while maintaining the same
-    // performance characteristics.
-    let x2: f32 = x * 0.5;
-    let mut y: f32 = x;
-
-    let mut i: i32 = y.to_bits() as i32;
-    i = 0x5f1ffff9 - (i >> 1);
-    y = f32::from_bits(i as u32);
-
-    y = 0.70395225 * y * (2.3892446 - (x2 * y * y));
-    y
-}


### PR DESCRIPTION
As discussed by @djeedai, Quat interpolation should use a spherical interpolation by default.