### PR TITLE
take advantage of ptr methods on dynamicbundle for children

### DIFF
--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -281,7 +281,7 @@ pub trait BundleEffect {
     fn apply(self, entity: &mut EntityWorldMut);
 
     /// # Safety
-    /// `this` must be a valid pointer to `Self` and takes ownership of the
+    /// `this` must be a valid but not aligned pointer to `Self` and takes ownership of the
     /// value pointed at by `this`.
     #[doc(hidden)]
     unsafe fn apply_raw(this: *mut Self, entity: &mut EntityWorldMut)
@@ -293,7 +293,7 @@ pub trait BundleEffect {
         // `BundleEffect`s onto the stack repeatedly.
 
         // SAFETY: Caller ensures that `this` is a valid pointer to `Self`.
-        unsafe { core::ptr::read(this).apply(entity) }
+        unsafe { core::ptr::read_unaligned(this).apply(entity) }
     }
 }
 

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -281,7 +281,7 @@ pub trait BundleEffect {
     fn apply(self, entity: &mut EntityWorldMut);
 
     /// # Safety
-    /// `this` must be a valid and well aligned pointer to `Self` and takes ownership of the
+    /// `this` must be a valid and aligned pointer to `Self` and takes ownership of the
     /// value pointed at by `this`.
     #[doc(hidden)]
     unsafe fn apply_raw(this: *mut Self, entity: &mut EntityWorldMut)

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -281,7 +281,7 @@ pub trait BundleEffect {
     fn apply(self, entity: &mut EntityWorldMut);
 
     /// # Safety
-    /// `this` must be a valid but not aligned pointer to `Self` and takes ownership of the
+    /// `this` must be a valid and well aligned pointer to `Self` and takes ownership of the
     /// value pointed at by `this`.
     #[doc(hidden)]
     unsafe fn apply_raw(this: *mut Self, entity: &mut EntityWorldMut)
@@ -293,7 +293,7 @@ pub trait BundleEffect {
         // `BundleEffect`s onto the stack repeatedly.
 
         // SAFETY: Caller ensures that `this` is a valid pointer to `Self`.
-        unsafe { core::ptr::read_unaligned(this).apply(entity) }
+        unsafe { core::ptr::read(this).apply(entity) }
     }
 }
 

--- a/crates/bevy_ecs/src/bundle/mod.rs
+++ b/crates/bevy_ecs/src/bundle/mod.rs
@@ -279,6 +279,22 @@ pub unsafe trait DynamicBundle {
 pub trait BundleEffect {
     /// Applies this effect to the given `entity`.
     fn apply(self, entity: &mut EntityWorldMut);
+
+    /// # Safety
+    /// `this` must be a valid pointer to `Self` and takes ownership of the
+    /// value pointed at by `this`.
+    #[doc(hidden)]
+    unsafe fn apply_raw(this: *mut Self, entity: &mut EntityWorldMut)
+    where
+        Self: Sized,
+    {
+        // Default to reading the pointer and calling the safe `apply` method.
+        // Implementers will want to override this to avoid copying big
+        // `BundleEffect`s onto the stack repeatedly.
+
+        // SAFETY: Caller ensures that `this` is a valid pointer to `Self`.
+        unsafe { core::ptr::read(this).apply(entity) }
+    }
 }
 
 /// A trait implemented for [`BundleEffect`] implementations that do nothing. This is used as a type constraint for

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -51,7 +51,7 @@ pub trait SpawnableList<R> {
     /// Implementors may want to implement a custom version of this function to
     /// avoid copying large values onto the stack repeatedly.
     /// # Safety
-    /// `this` must be a valid but not aligned pointer to `Self` and takes ownership of the
+    /// `this` must be a valid and well aligned pointer to `Self` and takes ownership of the
     /// value pointed at by `this`.
     #[doc(hidden)]
     unsafe fn spawn_raw(this: *mut Self, world: &mut World, entity: Entity)
@@ -60,7 +60,7 @@ pub trait SpawnableList<R> {
     {
         // SAFETY: this function must be called with a pointer to a valid `Self`.
         unsafe {
-            core::ptr::read_unaligned(this).spawn(world, entity);
+            core::ptr::read(this).spawn(world, entity);
         }
     }
 }

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -78,8 +78,9 @@ impl<R: Relationship, B: Bundle<Effect: NoBundleEffect>> SpawnableList<R> for Ve
 
 impl<R: Relationship, B: Bundle> SpawnableList<R> for Spawn<B> {
     fn spawn(self, world: &mut World, entity: Entity) {
+        let mut this = ManuallyDrop::new(self);
+        // SAFETY: `this` contains a valid `Self` we own.
         unsafe {
-            let mut this = ManuallyDrop::new(self);
             <Self as SpawnableList<R>>::spawn_raw((&raw mut (*this)), world, entity);
         }
     }

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -50,8 +50,10 @@ pub trait SpawnableList<R> {
     /// By default calls `self.spawn` with a raw pointer to `self`.
     /// Implementors may want to implement a custom version of this function to
     /// avoid copying large values onto the stack repeatedly.
+    ///
     /// # Safety
-    /// `this` must be a valid and well aligned pointer to `Self` and takes ownership of the
+    ///
+    /// `this` must be a valid and aligned pointer to `Self` and takes ownership of the
     /// value pointed at by `this`.
     #[doc(hidden)]
     unsafe fn spawn_raw(this: *mut Self, world: &mut World, entity: Entity)

--- a/crates/bevy_ecs/src/spawn.rs
+++ b/crates/bevy_ecs/src/spawn.rs
@@ -51,7 +51,7 @@ pub trait SpawnableList<R> {
     /// Implementors may want to implement a custom version of this function to
     /// avoid copying large values onto the stack repeatedly.
     /// # Safety
-    /// `this` must be a valid pointer to `Self` and takes ownership of the
+    /// `this` must be a valid but not aligned pointer to `Self` and takes ownership of the
     /// value pointed at by `this`.
     #[doc(hidden)]
     unsafe fn spawn_raw(this: *mut Self, world: &mut World, entity: Entity)
@@ -60,7 +60,7 @@ pub trait SpawnableList<R> {
     {
         // SAFETY: this function must be called with a pointer to a valid `Self`.
         unsafe {
-            core::ptr::read(this).spawn(world, entity);
+            core::ptr::read_unaligned(this).spawn(world, entity);
         }
     }
 }


### PR DESCRIPTION
- add `apply_raw` function to `BundleEffect`
- add `spawn_raw` function to `SpawnableList`

`SpawnRelatedBundle` can take advantage of the ptr-methds in dynamicbundle to avoid moving the child bundle to the stack.

# Objective

#20571

## Solution

add functions to traits to allow implementers of the traits to opt into taking advantage of the new dynamicbundle api

## Testing

cargo miri test --features=bevy_reflect/auto_register_static,bevy_reflect/debug,bevy_utils/debug

